### PR TITLE
handle issue2 - partial fix

### DIFF
--- a/apps/edge-tts/content.js
+++ b/apps/edge-tts/content.js
@@ -120,6 +120,7 @@ if (!window.__edge_tts_injected__) {
 
     // Recursive function to walk the DOM
     function processNode(node) {
+    
       // 1. If it's an Element, check if it's junk
       if (node.nodeType === Node.ELEMENT_NODE) {
         // If element matches junk selector, stop processing this branch
@@ -131,7 +132,7 @@ if (!window.__edge_tts_injected__) {
         return;
       }
 
-      // 2. If it's a Text Node, split into words
+      // 2. If it's a Text Node, split into words    
       if (node.nodeType === Node.TEXT_NODE) {
         const text = node.nodeValue;
         // Skip empty or whitespace-only nodes
@@ -253,7 +254,16 @@ if (!window.__edge_tts_injected__) {
 // Word highlighting mods --->
     // Safety check: Ensure we have spans to read
     if (state.highlightedSpans.length === 0) {
-      console.warn("Edge TTS: No words found to speak.");
+      console.log("Edge TTS: Error - No words found to speak.");
+
+      // Send the error message to the Popup here!
+      chrome.runtime.sendMessage({ 
+        command: "showError", 
+        message: "ⓘ Page is non-standard:\n \
+Navigation elements mixed with main content.\n\n \
+👉 Try selecting the specific text you want to read with your mouse, then click Play." 
+      });
+
       return;
     }
 

--- a/apps/edge-tts/popup.js
+++ b/apps/edge-tts/popup.js
@@ -83,10 +83,19 @@ async function handleStop() {
 // Listen for messages from content script
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.command === "finished") {
-    // Reading finished naturally
+    // Reset UI when reading finishes
     isPlaying = false;
     isPaused = false;
     updateUI();
+  } 
+  else if (request.command === "showError") {
+    // Reset UI and show alert on error
+    isPlaying = false;
+    isPaused = false;
+    updateUI();
+    
+    // Alert the user
+    alert(request.message);
   }
 });
 


### PR DESCRIPTION
## Partial fix for Issue 2

**Issue with Abplive website**: it mixes navigation elements with main content, hence parsing is difficult with junkselectors.
Fixing this specifically for Abplive will be a hacky solution, with several issues:
1. Needs to be processed before traversing the dom, hence possibility of breaking on other websites
2. Breaks the TTS of selected text
3. No word highlighting possible

**Proposed fix**:
Verify text length after junk removal. If zero length, show alert to user and advise selecting text for TTS.